### PR TITLE
Make click3 run on raspberry pi

### DIFF
--- a/clickclickclick/executor/osx.py
+++ b/clickclickclick/executor/osx.py
@@ -1,14 +1,15 @@
+from . import Executor
+from typing import List, Union
+import logging
+import io
+import base64
+from PIL import Image
+from tempfile import NamedTemporaryFile
+from . import logger
+
 try:
-    from . import Executor
     import pyautogui
-    from typing import List, Union
-    import logging
-    import io
-    import base64
-    from PIL import Image
     import applescript
-    from tempfile import NamedTemporaryFile
-    from . import logger
 except Exception as e:
     print(f"warn: import error in osx.py {e}")
 

--- a/clickclickclick/executor/osx.py
+++ b/clickclickclick/executor/osx.py
@@ -1,5 +1,9 @@
 from . import Executor
-import pyautogui
+try:
+    import pyautogui
+except ImportError:
+    print("warn: pyautogui is not found")
+
 from typing import List, Union
 import logging
 import io

--- a/clickclickclick/executor/osx.py
+++ b/clickclickclick/executor/osx.py
@@ -1,17 +1,16 @@
-from . import Executor
 try:
+    from . import Executor
     import pyautogui
+    from typing import List, Union
+    import logging
+    import io
+    import base64
+    from PIL import Image
+    import applescript
+    from tempfile import NamedTemporaryFile
+    from . import logger
 except Exception as e:
-    print(f"warn: pyautogui is not imported {e}")
-
-from typing import List, Union
-import logging
-import io
-import base64
-from PIL import Image
-import applescript
-from tempfile import NamedTemporaryFile
-from . import logger
+    print(f"warn: import error in osx.py {e}")
 
 
 class MacExecutor(Executor):

--- a/clickclickclick/executor/osx.py
+++ b/clickclickclick/executor/osx.py
@@ -1,8 +1,8 @@
 from . import Executor
 try:
     import pyautogui
-except ImportError:
-    print("warn: pyautogui is not found")
+except Exception as e:
+    print(f"warn: pyautogui is not imported {e}")
 
 from typing import List, Union
 import logging

--- a/clickclickclick/finder/__init__.py
+++ b/clickclickclick/finder/__init__.py
@@ -4,7 +4,6 @@ import subprocess
 import re
 import base64
 import json
-import pyautogui
 import logging
 from clickclickclick.executor import Executor
 from PIL import Image
@@ -111,6 +110,7 @@ class BaseFinder(ABC):
                 raise Exception("Failed to parse screen size from adb output.")
         except Exception as e:
             # Attempt to get screen size using pyautogui (for desktops)
+            import pyautogui
             screen_x, screen_y = pyautogui.size()
 
         print(f"Screen size: x y {screen_x} {screen_y}")

--- a/clickclickclick/finder/mlx.py
+++ b/clickclickclick/finder/mlx.py
@@ -1,8 +1,11 @@
 from clickclickclick.config import BaseConfig
 from . import BaseFinder, logger
-from mlx_vlm import load, generate
-from mlx_vlm.prompt_utils import apply_chat_template
-from mlx_vlm.utils import load_config
+try:
+    from mlx_vlm import load, generate
+    from mlx_vlm.prompt_utils import apply_chat_template
+    from mlx_vlm.utils import load_config
+except Exception as e:
+    print(f"warn: mlx-vlm import issue {e}")
 from tempfile import NamedTemporaryFile
 import re
 import json

--- a/interface.py
+++ b/interface.py
@@ -85,4 +85,4 @@ def run_gradio():
             outputs=[chatbot, state],
         )
 
-        gui.launch()
+        gui.launch(server_name="0.0.0.0", server_port=8080)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ dependencies = [
     "pyaml>=24.9.0",
     "pre-commit",
     "google-generativeai>=0.8",
-    "openai==1.55.0",
+    "openai",
     "ollama>=0.4.4",
     "google-ai-generativelanguage>=0.6.0",
     "black",

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ futures
 pillow
 google-generativeai
 py-applescript
-openai==1.55.0
+openai
 ollama
 google.ai.generativelanguage
 click


### PR DESCRIPTION
* pyautogui is now imported with try except
* applescript too
* mlx-vlm as well

Tested on Raspberry Pi Zero 2 W.
It's a little slower that macos - probably due to slower wifi chip / processor etc.

Gradio worked.